### PR TITLE
Introduce build-logic quality and testing plugins

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,0 +1,18 @@
+plugins {
+    `kotlin-dsl`
+}
+
+group = "com.abbott.mosaic"
+
+version = "1.0-SNAPSHOT"
+
+repositories {
+    mavenCentral()
+    gradlePluginPortal()
+}
+
+dependencies {
+    implementation("org.jlleitschuh.gradle:ktlint-gradle:12.1.0")
+    implementation("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.5")
+    implementation("org.jetbrains.kotlinx:kover-gradle-plugin:0.7.5")
+}

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "build-logic"

--- a/build-logic/src/main/kotlin/com.abbott.mosaic.quality.gradle.kts
+++ b/build-logic/src/main/kotlin/com.abbott.mosaic.quality.gradle.kts
@@ -1,0 +1,28 @@
+plugins {
+    id("org.jlleitschuh.gradle.ktlint")
+    id("io.gitlab.arturbosch.detekt")
+}
+
+ktlint {
+    version.set("1.0.1")
+    android.set(false)
+    verbose.set(true)
+    filter {
+        exclude { it.file.path.contains("build/") }
+    }
+    ignoreFailures.set(false)
+    reporters {
+        reporter(org.jlleitschuh.gradle.ktlint.reporter.ReporterType.PLAIN)
+        reporter(org.jlleitschuh.gradle.ktlint.reporter.ReporterType.CHECKSTYLE)
+        reporter(org.jlleitschuh.gradle.ktlint.reporter.ReporterType.HTML)
+    }
+}
+
+detekt {
+    config.setFrom(files("${rootProject.projectDir}/config/detekt/detekt.yml"))
+    buildUponDefaultConfig = true
+    allRules = false
+    autoCorrect = true
+    ignoreFailures = false
+    parallel = true
+}

--- a/build-logic/src/main/kotlin/com.abbott.mosaic.testing.gradle.kts
+++ b/build-logic/src/main/kotlin/com.abbott.mosaic.testing.gradle.kts
@@ -1,0 +1,31 @@
+plugins {
+    id("org.jetbrains.kotlinx.kover")
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
+    finalizedBy("koverHtmlReport")
+}
+
+dependencies {
+    add("testImplementation", kotlin("test"))
+    add("testImplementation", "org.junit.jupiter:junit-jupiter:5.10.0")
+}
+
+koverReport {
+    verify {
+        rule {
+            isEnabled = true
+            bound {
+                minValue = 80
+                metric = kotlinx.kover.gradle.plugin.dsl.MetricType.LINE
+                aggregation = kotlinx.kover.gradle.plugin.dsl.AggregationType.COVERED_PERCENTAGE
+            }
+            bound {
+                minValue = 80
+                metric = kotlinx.kover.gradle.plugin.dsl.MetricType.BRANCH
+                aggregation = kotlinx.kover.gradle.plugin.dsl.AggregationType.COVERED_PERCENTAGE
+            }
+        }
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,9 +5,8 @@
 
 plugins {
   kotlin("jvm") version "2.2.10" apply false
-  id("org.jlleitschuh.gradle.ktlint") version "12.1.0" apply false
-  id("io.gitlab.arturbosch.detekt") version "1.23.5" apply false
-  id("org.jetbrains.kotlinx.kover") version "0.7.5" apply false
+  id("com.abbott.mosaic.quality") apply false
+  id("com.abbott.mosaic.testing") apply false
 }
 
 // Configure all projects
@@ -23,14 +22,8 @@ allprojects {
 // Configure all subprojects
 subprojects {
   apply(plugin = "org.jetbrains.kotlin.jvm")
-  apply(plugin = "org.jlleitschuh.gradle.ktlint")
-  apply(plugin = "io.gitlab.arturbosch.detekt")
-  apply(plugin = "org.jetbrains.kotlinx.kover")
-
-  tasks.withType<Test> {
-    useJUnitPlatform()
-    finalizedBy("koverHtmlReport")
-  }
+  apply(plugin = "com.abbott.mosaic.quality")
+  apply(plugin = "com.abbott.mosaic.testing")
 
   tasks.register("styleCheck") {
     group = "verification"

--- a/mosaic-core/build.gradle.kts
+++ b/mosaic-core/build.gradle.kts
@@ -8,9 +8,7 @@
 
 dependencies {
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
-  testImplementation(kotlin("test"))
   testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
-  testImplementation("org.junit.jupiter:junit-jupiter:5.10.0")
 }
 
 kotlin {
@@ -20,61 +18,5 @@ kotlin {
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
   compilerOptions {
     jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
-  }
-}
-
-// ktlint configuration
-ktlint {
-  version.set("1.0.1")
-  android.set(false)
-  verbose.set(true)
-  filter {
-    exclude { element -> element.file.path.contains("build/") }
-  }
-  ignoreFailures.set(false)
-  reporters {
-    reporter(org.jlleitschuh.gradle.ktlint.reporter.ReporterType.PLAIN)
-    reporter(org.jlleitschuh.gradle.ktlint.reporter.ReporterType.CHECKSTYLE)
-    reporter(org.jlleitschuh.gradle.ktlint.reporter.ReporterType.HTML)
-  }
-}
-
-// detekt configuration
-detekt {
-  config.setFrom(files("${rootProject.projectDir}/config/detekt/detekt.yml"))
-  buildUponDefaultConfig = true
-  allRules = false
-  autoCorrect = true
-  ignoreFailures = false
-  parallel = true
-}
-
-// kover configuration
-koverReport {
-  filters {
-    excludes {
-      classes("**.*Test*")
-      classes("**.*Test")
-      classes("**.*Tests")
-    }
-  }
-
-  verify {
-    rule {
-      isEnabled = true
-      entity = kotlinx.kover.gradle.plugin.dsl.GroupingEntityType.APPLICATION
-
-      bound {
-        minValue = 80
-        metric = kotlinx.kover.gradle.plugin.dsl.MetricType.LINE
-        aggregation = kotlinx.kover.gradle.plugin.dsl.AggregationType.COVERED_PERCENTAGE
-      }
-
-      bound {
-        minValue = 80
-        metric = kotlinx.kover.gradle.plugin.dsl.MetricType.BRANCH
-        aggregation = kotlinx.kover.gradle.plugin.dsl.AggregationType.COVERED_PERCENTAGE
-      }
-    }
   }
 }

--- a/mosaic-test/build.gradle.kts
+++ b/mosaic-test/build.gradle.kts
@@ -32,32 +32,6 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
   }
 }
 
-// ktlint configuration
-ktlint {
-  version.set("1.0.1")
-  android.set(false)
-  verbose.set(true)
-  filter {
-    exclude { element -> element.file.path.contains("build/") }
-  }
-  ignoreFailures.set(false)
-  reporters {
-    reporter(org.jlleitschuh.gradle.ktlint.reporter.ReporterType.PLAIN)
-    reporter(org.jlleitschuh.gradle.ktlint.reporter.ReporterType.CHECKSTYLE)
-    reporter(org.jlleitschuh.gradle.ktlint.reporter.ReporterType.HTML)
-  }
-}
-
-// detekt configuration
-detekt {
-  config.setFrom(files("${rootProject.projectDir}/config/detekt/detekt.yml"))
-  buildUponDefaultConfig = true
-  allRules = false
-  autoCorrect = true
-  ignoreFailures = false
-  parallel = true
-}
-
 // kover configuration - reasonable thresholds based on achieved coverage
 koverReport {
   filters {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,6 +9,10 @@
 
 rootProject.name = "Mosaic"
 
+pluginManagement {
+    includeBuild("build-logic")
+}
+
 include("mosaic-core")
 include("mosaic-test")
 


### PR DESCRIPTION
## Summary
- confirm ktlint/detekt configuration uses conventional rules
- add `build-logic` testing plugin configuring Kover and JUnit
- apply testing plugin across modules and drop redundant test config

## Testing
- `./gradlew ktlintCheck`
- `./gradlew detekt`
- `./gradlew koverVerify`


------
https://chatgpt.com/codex/tasks/task_e_68aac35964508333a8097a9ce098dc32