### PR TITLE
feat: add mosaic build plugin

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,8 @@ coroutines = "1.10.2"
 junit = "5.10.2"
 mockk = "1.14.5"
 assertj = "3.27.4"
+kotlinpoet = "2.2.0"
+classgraph = "4.8.180"
 
 [libraries]
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
@@ -19,6 +21,8 @@ assertj = { module = "org.assertj:assertj-core", version.ref = "assertj" }
 ktlint-gradle = { module = "org.jlleitschuh.gradle:ktlint-gradle", version.ref = "ktlint" }
 detekt-gradle-plugin = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detekt" }
 kover-gradle-plugin = { module = "org.jetbrains.kotlinx:kover-gradle-plugin", version.ref = "kover" }
+kotlinpoet = { module = "com.squareup:kotlinpoet", version.ref = "kotlinpoet" }
+classgraph = { module = "io.github.classgraph:classgraph", version.ref = "classgraph" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/mosaic-build/build.gradle.kts
+++ b/mosaic-build/build.gradle.kts
@@ -1,0 +1,24 @@
+/*
+ * Mosaic Build module build.gradle.kts
+ * This module provides a Gradle plugin for automatic Mosaic tile registration
+ */
+
+
+plugins {
+  `java-gradle-plugin`
+}
+
+dependencies {
+  implementation(project(":mosaic-core"))
+  implementation(libs.kotlinpoet)
+  implementation(libs.classgraph)
+}
+
+gradlePlugin {
+  plugins {
+    create("mosaicBuild") {
+      id = "com.abbott.mosaic.build"
+      implementationClass = "com.abbott.mosaic.build.MosaicBuildPlugin"
+    }
+  }
+}

--- a/mosaic-build/src/main/kotlin/com/abbott/mosaic/build/MosaicBuildPlugin.kt
+++ b/mosaic-build/src/main/kotlin/com/abbott/mosaic/build/MosaicBuildPlugin.kt
@@ -1,0 +1,74 @@
+package com.abbott.mosaic.build
+
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.FunSpec
+import io.github.classgraph.ClassGraph
+import org.gradle.api.DefaultTask
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.SourceSetContainer
+import org.gradle.api.tasks.TaskAction
+
+abstract class GenerateMosaicRegistryTask : DefaultTask() {
+  @get:InputFiles
+  abstract val classpath: ConfigurableFileCollection
+
+  @get:OutputDirectory
+  abstract val outputDir: DirectoryProperty
+
+  @TaskAction
+  fun generate() {
+    val scanResult =
+      ClassGraph()
+        .overrideClasspath(classpath.files)
+        .enableClassInfo()
+        .scan()
+
+    val tileClasses = scanResult.getSubclasses("com.abbott.mosaic.Tile")
+    if (tileClasses.isEmpty()) return
+
+    val registerFun =
+      FunSpec
+        .builder("registerGeneratedTiles")
+        .receiver(ClassName("com.abbott.mosaic", "MosaicRegistry"))
+
+    tileClasses.forEach { classInfo ->
+      val className = ClassName.bestGuess(classInfo.name)
+      registerFun.addStatement(
+        "register(%T::class) { mosaic -> %T(mosaic) }",
+        className,
+        className,
+      )
+    }
+
+    val fileSpec =
+      FileSpec
+        .builder("com.abbott.mosaic.generated", "GeneratedMosaicRegistry")
+        .addFunction(registerFun.build())
+        .build()
+
+    val outDir = outputDir.get().asFile
+    outDir.deleteRecursively()
+    fileSpec.writeTo(outDir.toPath())
+  }
+}
+
+class MosaicBuildPlugin : Plugin<Project> {
+  override fun apply(project: Project) {
+    val sourceSets = project.extensions.getByType(SourceSetContainer::class.java)
+    val generateTask =
+      project.tasks.register("generateMosaicRegistry", GenerateMosaicRegistryTask::class.java) { task ->
+        task.outputDir.set(project.layout.buildDirectory.dir("generated/mosaic"))
+        task.classpath.setFrom(project.configurations.getByName("compileClasspath"))
+      }
+
+    sourceSets.getByName("main").java.srcDir(generateTask.map { it.outputDir })
+
+    project.tasks.named("compileKotlin").configure { it.dependsOn(generateTask) }
+  }
+}

--- a/mosaic-build/src/test/kotlin/com/abbott/mosaic/TestTile.kt
+++ b/mosaic-build/src/test/kotlin/com/abbott/mosaic/TestTile.kt
@@ -1,0 +1,5 @@
+package com.abbott.mosaic
+
+class TestTile(mosaic: Mosaic) : SingleTile<String>(mosaic) {
+  override suspend fun retrieve(): String = "value"
+}

--- a/mosaic-build/src/test/kotlin/com/abbott/mosaic/buildplugin/MosaicBuildPluginSpec.kt
+++ b/mosaic-build/src/test/kotlin/com/abbott/mosaic/buildplugin/MosaicBuildPluginSpec.kt
@@ -1,0 +1,73 @@
+package com.abbott.mosaic.buildplugin
+
+import com.abbott.mosaic.TestTile
+import com.abbott.mosaic.Tile
+import java.io.File
+import kotlin.io.path.exists
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import com.abbott.mosaic.build.GenerateMosaicRegistryTask
+
+class MosaicBuildPluginSpec {
+  @Test
+  fun `plugin registers task and compile dependency`() {
+    val project = ProjectBuilder.builder().build()
+    project.plugins.apply("java")
+    val compileKotlin = project.tasks.register("compileKotlin")
+
+    project.plugins.apply("com.abbott.mosaic.build")
+
+    val generateProvider = project.tasks.named("generateMosaicRegistry")
+    val generate = generateProvider.get()
+
+    val sourceSets = project.extensions.getByName("sourceSets") as org.gradle.api.tasks.SourceSetContainer
+    val generatedDir = project.layout.buildDirectory.dir("generated/mosaic").get().asFile
+    assertTrue(sourceSets.getByName("main").java.srcDirs.contains(generatedDir))
+
+    val dependsOnNames = compileKotlin.get().dependsOn.map { dep ->
+      when (dep) {
+        is org.gradle.api.Task -> dep.name
+        is org.gradle.api.tasks.TaskProvider<*> -> dep.name
+        else -> dep.toString()
+      }
+    }
+    assertTrue("generateMosaicRegistry" in dependsOnNames)
+  }
+
+  @Test
+  fun `task generates registry for tiles`(@TempDir tempDir: Path) {
+    val project = ProjectBuilder.builder().withProjectDir(tempDir.toFile()).build()
+    val task = project.tasks.create("generate", GenerateMosaicRegistryTask::class.java)
+    val outDir = tempDir.resolve("out").toFile()
+    task.outputDir.set(outDir)
+    task.classpath.from(
+      File(TestTile::class.java.protectionDomain.codeSource.location.toURI()),
+      File(Tile::class.java.protectionDomain.codeSource.location.toURI()),
+    )
+
+    task.generate()
+
+    val generated = outDir.toPath().resolve("com/abbott/mosaic/generated/GeneratedMosaicRegistry.kt")
+    assertTrue(generated.exists())
+    val text = generated.toFile().readText()
+    assertTrue(text.contains("register(TestTile::class) { mosaic -> TestTile(mosaic) }"))
+  }
+
+  @Test
+  fun `task does nothing when no tiles found`(@TempDir tempDir: Path) {
+    val project = ProjectBuilder.builder().withProjectDir(tempDir.toFile()).build()
+    val task = project.tasks.create("generate", GenerateMosaicRegistryTask::class.java)
+    val outDir = tempDir.resolve("out").toFile()
+    task.outputDir.set(outDir)
+    task.classpath.from(outDir)
+
+    task.generate()
+
+    val generated = outDir.toPath().resolve("com/abbott/mosaic/generated/GeneratedMosaicRegistry.kt").toFile()
+    assertFalse(generated.exists())
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,6 +16,7 @@ dependencyResolutionManagement {
 
 include("mosaic-core")
 include("mosaic-test")
+include("mosaic-build")
 
 // Future modules can be added here:
 // include("mosaic-api")


### PR DESCRIPTION
## Summary
- add Mosaic Build plugin to generate tile registration code
- use KotlinPoet and ClassGraph for compile-time scanning
- add versions and Gradle module wiring
- cover build plugin with unit tests

## Testing
- `./gradlew :mosaic-build:test`
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68ab336a9e388333ab5759cdb181c23f