### PR TITLE
feat(test): auto-register tiles in TestMosaicBuilder

### DIFF
--- a/mosaic-test/README.md
+++ b/mosaic-test/README.md
@@ -45,6 +45,10 @@ This module depends on:
 
 ## 🚀 Usage
 
+When the `mosaic-build` Gradle plugin is applied, the test builder automatically registers all real
+`Tile` implementations before applying mocks. If you choose to register tiles manually, you can still
+do so by calling `MosaicRegistry.register` yourself.
+
 ### Basic Tile Testing
 
 ```kotlin
@@ -53,9 +57,6 @@ fun `should test single tile with success behavior`() = runTestMosaicTest {
     val testMosaic = TestMosaicBuilder()
         .withMockTile(TestSingleTile::class, "test-data", MockBehavior.SUCCESS)
         .build()
-    
-    registry.register(TestSingleTile::class) { testMosaic.getMockTiles()[TestSingleTile::class] as TestSingleTile }
-    
     testMosaic.assertEquals(tileClass = TestSingleTile::class, expected = "test-data")
 }
 ```
@@ -68,9 +69,6 @@ fun `should test multi tile with delay behavior`() = runTestMosaicTest {
     val testMosaic = TestMosaicBuilder()
         .withMockMultiTile(TestMultiTile::class, mapOf("key1" to "value1"), MockBehavior.DELAY)
         .build()
-    
-    registry.register(TestMultiTile::class) { testMosaic.getMockTiles()[TestMultiTile::class] as TestMultiTile }
-    
     testMosaic.assertEquals(
         tileClass = TestMultiTile::class,
         keys = listOf("key1"),
@@ -87,9 +85,6 @@ fun `should test error behavior`() = runTestMosaicTest {
     val testMosaic = TestMosaicBuilder()
         .withMockTile(TestSingleTile::class, "error-data", MockBehavior.ERROR)
         .build()
-    
-    registry.register(TestSingleTile::class) { testMosaic.getMockTiles()[TestSingleTile::class] as TestSingleTile }
-    
     testMosaic.assertThrows(tileClass = TestSingleTile::class, expectedException = RuntimeException::class.java)
 }
 ```
@@ -104,11 +99,6 @@ fun `should test multiple tiles with different behaviors`() = runTestMosaicTest 
         .withMockMultiTile(TestMultiTile::class, mapOf("key1" to "delay-value"), MockBehavior.DELAY)
         .withRequest(MockMosaicRequest())
         .build()
-    
-    // Test both tiles
-    registry.register(TestSingleTile::class) { testMosaic.getMockTiles()[TestSingleTile::class] as TestSingleTile }
-    registry.register(TestMultiTile::class) { testMosaic.getMockTiles()[TestMultiTile::class] as TestMultiTile }
-    
     testMosaic.assertEquals(tileClass = TestSingleTile::class, expected = "success-data")
     testMosaic.assertEquals(
         tileClass = TestMultiTile::class,

--- a/mosaic-test/src/main/kotlin/com/abbott/mosaic/test/TestMosaicBuilder.kt
+++ b/mosaic-test/src/main/kotlin/com/abbott/mosaic/test/TestMosaicBuilder.kt
@@ -52,10 +52,6 @@ class TestMosaicBuilder {
   ): TestMosaicBuilder {
     val mockTile = createMockTileWithMockK(tileClass, returnData, behavior)
     mockTiles[tileClass] = mockTile
-
-    internalRegistry.register(tileClass) { _ ->
-      mockTile
-    }
     return this
   }
 
@@ -88,10 +84,6 @@ class TestMosaicBuilder {
   ): TestMosaicBuilder {
     val mockTile = createMockTileWithMockK(tileClass, returnData, behavior)
     mockTiles[tileClass] = mockTile
-
-    internalRegistry.register(tileClass) { _ ->
-      mockTile
-    }
     return this
   }
 
@@ -126,6 +118,18 @@ class TestMosaicBuilder {
    * @return A TestMosaic with the configured mocks and request
    */
   fun build(): TestMosaic {
+    runCatching {
+      Class
+        .forName("com.abbott.mosaic.generated.GeneratedMosaicRegistryKt")
+        .getMethod("registerGeneratedTiles", MosaicRegistry::class.java)
+        .invoke(null, internalRegistry)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    mockTiles.forEach { (clazz, tile) ->
+      internalRegistry.register(clazz as KClass<Tile>) { tile }
+    }
+
     val mosaic = Mosaic(internalRegistry, request)
     return TestMosaic(mosaic, mockTiles)
   }

--- a/mosaic-test/src/test/kotlin/com/abbott/mosaic/generated/GeneratedMosaicRegistry.kt
+++ b/mosaic-test/src/test/kotlin/com/abbott/mosaic/generated/GeneratedMosaicRegistry.kt
@@ -1,0 +1,18 @@
+package com.abbott.mosaic.generated
+
+import com.abbott.mosaic.MosaicRegistry
+import com.abbott.mosaic.test.TestErrorMultiTile
+import com.abbott.mosaic.test.TestErrorSingleTile
+import com.abbott.mosaic.test.TestMultiTile
+import com.abbott.mosaic.test.TestProductTile
+import com.abbott.mosaic.test.TestSingleTile
+import com.abbott.mosaic.test.TestUserTile
+
+fun MosaicRegistry.registerGeneratedTiles() {
+  register(TestSingleTile::class) { mosaic -> TestSingleTile(mosaic) }
+  register(TestErrorSingleTile::class) { mosaic -> TestErrorSingleTile(mosaic) }
+  register(TestMultiTile::class) { mosaic -> TestMultiTile(mosaic) }
+  register(TestErrorMultiTile::class) { mosaic -> TestErrorMultiTile(mosaic) }
+  register(TestUserTile::class) { mosaic -> TestUserTile(mosaic) }
+  register(TestProductTile::class) { mosaic -> TestProductTile(mosaic) }
+}

--- a/mosaic-test/src/test/kotlin/com/abbott/mosaic/test/TestMosaicBuilderTest.kt
+++ b/mosaic-test/src/test/kotlin/com/abbott/mosaic/test/TestMosaicBuilderTest.kt
@@ -508,8 +508,6 @@ class TestMosaicBuilderTest : BaseTestMosaicTest() {
           .withMockTile(TestSingleTile::class, "delay-data", MockBehavior.DELAY)
           .build()
 
-      registry.register(TestSingleTile::class) { testMosaic.getMockTiles()[TestSingleTile::class] as TestSingleTile }
-
       // When & Then - This should trigger the DELAY branch
       testMosaic.assertEquals(tileClass = TestSingleTile::class, expected = "delay-data")
     }
@@ -523,8 +521,6 @@ class TestMosaicBuilderTest : BaseTestMosaicTest() {
           .withMockTile(TestSingleTile::class, "custom-data", MockBehavior.CUSTOM)
           .build()
 
-      registry.register(TestSingleTile::class) { testMosaic.getMockTiles()[TestSingleTile::class] as TestSingleTile }
-
       // When & Then - This should trigger the CUSTOM branch
       testMosaic.assertEquals(tileClass = TestSingleTile::class, expected = "custom-data")
     }
@@ -537,8 +533,6 @@ class TestMosaicBuilderTest : BaseTestMosaicTest() {
         builder
           .withMockMultiTile(TestMultiTile::class, mapOf("key1" to "delay-value"), MockBehavior.DELAY)
           .build()
-
-      registry.register(TestMultiTile::class) { testMosaic.getMockTiles()[TestMultiTile::class] as TestMultiTile }
 
       // When & Then - This should trigger the DELAY branch
       testMosaic.assertEquals(
@@ -557,8 +551,6 @@ class TestMosaicBuilderTest : BaseTestMosaicTest() {
           .withMockMultiTile(TestMultiTile::class, mapOf("key1" to "custom-value"), MockBehavior.CUSTOM)
           .build()
 
-      registry.register(TestMultiTile::class) { testMosaic.getMockTiles()[TestMultiTile::class] as TestMultiTile }
-
       // When & Then - This should trigger the CUSTOM branch
       testMosaic.assertEquals(
         tileClass = TestMultiTile::class,
@@ -576,8 +568,6 @@ class TestMosaicBuilderTest : BaseTestMosaicTest() {
           .withMockMultiTile(TestMultiTile::class, mapOf("key1" to "error-value"), MockBehavior.ERROR)
           .build()
 
-      registry.register(TestMultiTile::class) { testMosaic.getMockTiles()[TestMultiTile::class] as TestMultiTile }
-
       // When & Then - This should trigger the ERROR branch and throw
       testMosaic.assertThrows(
         tileClass = TestMultiTile::class,
@@ -594,8 +584,6 @@ class TestMosaicBuilderTest : BaseTestMosaicTest() {
         builder
           .withMockTile(TestSingleTile::class, "error-data", MockBehavior.ERROR)
           .build()
-
-      registry.register(TestSingleTile::class) { testMosaic.getMockTiles()[TestSingleTile::class] as TestSingleTile }
 
       // When & Then - This should trigger the ERROR branch and throw
       testMosaic.assertThrows(tileClass = TestSingleTile::class, expectedException = RuntimeException::class.java)


### PR DESCRIPTION
## Summary
- Automatically invoke the generated `registerGeneratedTiles` function during test Mosaic building
- Remove manual registry setup in tests and document automatic registration
- Add generated registry fixture for unit tests without wildcard imports
- Fix ktlint formatting in the generated registry fixture

## Testing
- `./gradlew build`
- `./gradlew detekt`
- `./gradlew ktlintCheck`
- `./gradlew test`
- `./gradlew koverXmlReport`


------
https://chatgpt.com/codex/tasks/task_e_68ab4087ebc883338a51e8480337a8e4