### PR TITLE
Add unit tests for spring example

### DIFF
--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -1,12 +1,12 @@
 plugins {
   id("kotlin.convention") apply false
   id("quality.convention") apply false
-//  id("com.abbott.mosaic.testing") apply false
+  id("testing.convention") apply false
 }
 
 subprojects {
   apply(plugin = "kotlin.convention")
   apply(plugin = "quality.convention")
-//  apply(plugin = "com.abbott.mosaic.testing")
+  apply(plugin = "testing.convention")
 }
 

--- a/examples/spring-example/build.gradle.kts
+++ b/examples/spring-example/build.gradle.kts
@@ -9,6 +9,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-web:3.2.5")
   implementation(libs.kotlinx.coroutines.core)
   ksp(project(":mosaic-build"))
+  testImplementation(project(":mosaic-test"))
 }
 
 application {

--- a/examples/spring-example/src/test/kotlin/com/abbott/mosaic/examples/spring/orders/ApplicationTest.kt
+++ b/examples/spring-example/src/test/kotlin/com/abbott/mosaic/examples/spring/orders/ApplicationTest.kt
@@ -1,0 +1,22 @@
+package com.abbott.mosaic.examples.spring.orders
+
+import com.abbott.mosaic.examples.spring.orders.web.OrderController
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+
+class ApplicationTest {
+  @Test
+  fun `mosaic registry is created`() {
+    val registry = MosaicConfig().mosaicRegistry()
+    assertNotNull(registry)
+  }
+
+  @Test
+  fun `order controller returns order page`() {
+    val registry = MosaicConfig().mosaicRegistry()
+    val controller = OrderController(registry)
+    val page = controller.getOrder("order-1")
+    assertEquals("order-1", page.summary.order.id)
+  }
+}

--- a/examples/spring-example/src/test/kotlin/com/abbott/mosaic/examples/spring/orders/service/ServicesTest.kt
+++ b/examples/spring-example/src/test/kotlin/com/abbott/mosaic/examples/spring/orders/service/ServicesTest.kt
@@ -1,0 +1,64 @@
+package com.abbott.mosaic.examples.spring.orders.service
+
+import com.abbott.mosaic.examples.spring.orders.model.Address
+import com.abbott.mosaic.examples.spring.orders.model.Customer
+import com.abbott.mosaic.examples.spring.orders.model.Order
+import com.abbott.mosaic.examples.spring.orders.model.OrderLineItem
+import com.abbott.mosaic.examples.spring.orders.model.Price
+import com.abbott.mosaic.examples.spring.orders.model.Product
+import com.abbott.mosaic.examples.spring.orders.model.Quote
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class ServicesTest {
+  @Test
+  fun `services return expected data`() {
+    val order = OrderService.getOrder("order-1")
+    val expectedOrder =
+      Order(
+        id = "order-1",
+        customerId = "customer-1",
+        items =
+          listOf(
+            OrderLineItem("product-1", "sku-1", 2),
+            OrderLineItem("product-2", "sku-2", 1),
+          ),
+      )
+    assertEquals(expectedOrder, order)
+
+    val customer = CustomerService.getCustomer("customer-1")
+    assertEquals(Customer("customer-1", "Jane Doe"), customer)
+
+    val products = ProductService.getProducts(listOf("product-1", "product-2"))
+    val expectedProducts =
+      mapOf(
+        "product-1" to Product("product-1", "Coffee Mug"),
+        "product-2" to Product("product-2", "Tea Kettle"),
+      )
+    assertEquals(expectedProducts, products)
+
+    val prices = PricingService.getPrices(listOf("sku-1", "sku-2"))
+    val expectedPrices =
+      mapOf(
+        "sku-1" to Price("sku-1", 12.99),
+        "sku-2" to Price("sku-2", 29.99),
+      )
+    assertEquals(expectedPrices, prices)
+
+    val address = AddressService.getAddress("order-1")
+    assertEquals(Address("123 Main St", "Springfield"), address)
+
+    val carriers = CarrierService.getAvailableCarriers()
+    val expectedCarriers = listOf("UPS", "FEDEX", "DHL")
+    assertEquals(expectedCarriers, carriers)
+
+    val quotes = CarrierService.getQuotes(address, carriers)
+    val expectedQuotes =
+      mapOf(
+        "UPS" to Quote("UPS", 5.99),
+        "FEDEX" to Quote("FEDEX", 7.49),
+        "DHL" to Quote("DHL", 6.49),
+      )
+    assertEquals(expectedQuotes, quotes)
+  }
+}

--- a/examples/spring-example/src/test/kotlin/com/abbott/mosaic/examples/spring/orders/tile/TilesTest.kt
+++ b/examples/spring-example/src/test/kotlin/com/abbott/mosaic/examples/spring/orders/tile/TilesTest.kt
@@ -18,149 +18,159 @@ import org.junit.jupiter.api.Test
 
 class TilesTest {
   @Test
-  fun `order tile returns order from request`() = runBlocking {
-    val expected =
-      Order(
-        id = "order-1",
-        customerId = "customer-1",
-        items =
-          listOf(
-            OrderLineItem("product-1", "sku-1", 2),
-            OrderLineItem("product-2", "sku-2", 1),
+  fun `order tile returns order from request`() =
+    runBlocking {
+      val expected =
+        Order(
+          id = "order-1",
+          customerId = "customer-1",
+          items =
+            listOf(
+              OrderLineItem("product-1", "sku-1", 2),
+              OrderLineItem("product-2", "sku-2", 1),
+            ),
+        )
+      val testMosaic = TestMosaicBuilder().withRequest(OrderRequest("order-1")).build()
+      testMosaic.assertEquals(OrderTile::class, expected)
+    }
+
+  @Test
+  fun `customer tile uses order tile`() =
+    runBlocking {
+      val order = Order("order-1", "customer-1", emptyList())
+      val expected = Customer("customer-1", "Jane Doe")
+      val testMosaic = TestMosaicBuilder().withMockTile(OrderTile::class, order).build()
+      testMosaic.assertEquals(CustomerTile::class, expected)
+    }
+
+  @Test
+  fun `products tile fetches products`() =
+    runBlocking {
+      val keys = listOf("product-1", "product-2")
+      val expected =
+        mapOf(
+          "product-1" to Product("product-1", "Coffee Mug"),
+          "product-2" to Product("product-2", "Tea Kettle"),
+        )
+      val testMosaic = TestMosaicBuilder().build()
+      testMosaic.assertEquals(ProductsByIdTile::class, keys, expected)
+    }
+
+  @Test
+  fun `pricing tile fetches prices`() =
+    runBlocking {
+      val keys = listOf("sku-1", "sku-2")
+      val expected =
+        mapOf(
+          "sku-1" to Price("sku-1", 12.99),
+          "sku-2" to Price("sku-2", 29.99),
+        )
+      val testMosaic = TestMosaicBuilder().build()
+      testMosaic.assertEquals(PricingBySkuTile::class, keys, expected)
+    }
+
+  @Test
+  fun `address tile uses request id`() =
+    runBlocking {
+      val testMosaic = TestMosaicBuilder().withRequest(OrderRequest("order-1")).build()
+      val expected = Address("123 Main St", "Springfield")
+      testMosaic.assertEquals(AddressTile::class, expected)
+    }
+
+  @Test
+  fun `carrier quotes tile uses address tile`() =
+    runBlocking {
+      val address = Address("123 Main St", "Springfield")
+      val carriers = listOf("UPS", "FEDEX")
+      val quotes =
+        mapOf(
+          "UPS" to Quote("UPS", 5.99),
+          "FEDEX" to Quote("FEDEX", 7.49),
+        )
+      val testMosaic = TestMosaicBuilder().withMockTile(AddressTile::class, address).build()
+      testMosaic.assertEquals(CarrierQuotesTile::class, carriers, quotes)
+    }
+
+  @Test
+  fun `logistics tile combines address and quotes`() =
+    runBlocking {
+      val address = Address("123 Main St", "Springfield")
+      val quotes =
+        mapOf(
+          "UPS" to Quote("UPS", 5.99),
+          "FEDEX" to Quote("FEDEX", 7.49),
+          "DHL" to Quote("DHL", 6.49),
+        )
+      val expected = Logistics(address, quotes)
+      val testMosaic =
+        TestMosaicBuilder()
+          .withMockTile(AddressTile::class, address)
+          .withMockMultiTile(CarrierQuotesTile::class, quotes)
+          .build()
+      testMosaic.assertEquals(LogisticsTile::class, expected)
+    }
+
+  @Test
+  fun `line items tile combines other tiles`() =
+    runBlocking {
+      val order =
+        Order(
+          id = "order-1",
+          customerId = "customer-1",
+          items = listOf(OrderLineItem("product-1", "sku-1", 2)),
+        )
+      val products = mapOf("product-1" to Product("product-1", "Coffee Mug"))
+      val prices = mapOf("sku-1" to Price("sku-1", 12.99))
+      val expected =
+        listOf(
+          LineItemDetail(
+            product = products.getValue("product-1"),
+            price = prices.getValue("sku-1"),
+            quantity = 2,
           ),
-      )
-    val testMosaic = TestMosaicBuilder().withRequest(OrderRequest("order-1")).build()
-    testMosaic.assertEquals(OrderTile::class, expected)
-  }
+        )
+      val testMosaic =
+        TestMosaicBuilder()
+          .withMockTile(OrderTile::class, order)
+          .withMockMultiTile(ProductsByIdTile::class, products)
+          .withMockMultiTile(PricingBySkuTile::class, prices)
+          .build()
+      testMosaic.assertEquals(LineItemsTile::class, expected)
+    }
 
   @Test
-  fun `customer tile uses order tile`() = runBlocking {
-    val order = Order("order-1", "customer-1", emptyList())
-    val expected = Customer("customer-1", "Jane Doe")
-    val testMosaic = TestMosaicBuilder().withMockTile(OrderTile::class, order).build()
-    testMosaic.assertEquals(CustomerTile::class, expected)
-  }
+  fun `order summary tile aggregates data`() =
+    runBlocking {
+      val order = Order("order-1", "customer-1", emptyList())
+      val customer = Customer("customer-1", "Jane Doe")
+      val lineItems =
+        listOf(LineItemDetail(Product("product-1", "Coffee Mug"), Price("sku-1", 12.99), 2))
+      val expected = OrderSummary(order, customer, lineItems)
+      val testMosaic =
+        TestMosaicBuilder()
+          .withMockTile(OrderTile::class, order)
+          .withMockTile(CustomerTile::class, customer)
+          .withMockTile(LineItemsTile::class, lineItems)
+          .build()
+      testMosaic.assertEquals(OrderSummaryTile::class, expected)
+    }
 
   @Test
-  fun `products tile fetches products`() = runBlocking {
-    val keys = listOf("product-1", "product-2")
-    val expected =
-      mapOf(
-        "product-1" to Product("product-1", "Coffee Mug"),
-        "product-2" to Product("product-2", "Tea Kettle"),
-      )
-    val testMosaic = TestMosaicBuilder().build()
-    testMosaic.assertEquals(ProductsByIdTile::class, keys, expected)
-  }
-
-  @Test
-  fun `pricing tile fetches prices`() = runBlocking {
-    val keys = listOf("sku-1", "sku-2")
-    val expected =
-      mapOf(
-        "sku-1" to Price("sku-1", 12.99),
-        "sku-2" to Price("sku-2", 29.99),
-      )
-    val testMosaic = TestMosaicBuilder().build()
-    testMosaic.assertEquals(PricingBySkuTile::class, keys, expected)
-  }
-
-  @Test
-  fun `address tile uses request id`() = runBlocking {
-    val testMosaic = TestMosaicBuilder().withRequest(OrderRequest("order-1")).build()
-    val expected = Address("123 Main St", "Springfield")
-    testMosaic.assertEquals(AddressTile::class, expected)
-  }
-
-  @Test
-  fun `carrier quotes tile uses address tile`() = runBlocking {
-    val address = Address("123 Main St", "Springfield")
-    val carriers = listOf("UPS", "FEDEX")
-    val quotes =
-      mapOf(
-        "UPS" to Quote("UPS", 5.99),
-        "FEDEX" to Quote("FEDEX", 7.49),
-      )
-    val testMosaic = TestMosaicBuilder().withMockTile(AddressTile::class, address).build()
-    testMosaic.assertEquals(CarrierQuotesTile::class, carriers, quotes)
-  }
-
-  @Test
-  fun `logistics tile combines address and quotes`() = runBlocking {
-    val address = Address("123 Main St", "Springfield")
-    val quotes =
-      mapOf(
-        "UPS" to Quote("UPS", 5.99),
-        "FEDEX" to Quote("FEDEX", 7.49),
-        "DHL" to Quote("DHL", 6.49),
-      )
-    val expected = Logistics(address, quotes)
-    val testMosaic =
-      TestMosaicBuilder()
-        .withMockTile(AddressTile::class, address)
-        .withMockMultiTile(CarrierQuotesTile::class, quotes)
-        .build()
-    testMosaic.assertEquals(LogisticsTile::class, expected)
-  }
-
-  @Test
-  fun `line items tile combines other tiles`() = runBlocking {
-    val order =
-      Order(
-        id = "order-1",
-        customerId = "customer-1",
-        items = listOf(OrderLineItem("product-1", "sku-1", 2)),
-      )
-    val products = mapOf("product-1" to Product("product-1", "Coffee Mug"))
-    val prices = mapOf("sku-1" to Price("sku-1", 12.99))
-    val expected =
-      listOf(
-        LineItemDetail(
-          product = products.getValue("product-1"),
-          price = prices.getValue("sku-1"),
-          quantity = 2,
-        ),
-      )
-    val testMosaic =
-      TestMosaicBuilder()
-        .withMockTile(OrderTile::class, order)
-        .withMockMultiTile(ProductsByIdTile::class, products)
-        .withMockMultiTile(PricingBySkuTile::class, prices)
-        .build()
-    testMosaic.assertEquals(LineItemsTile::class, expected)
-  }
-
-  @Test
-  fun `order summary tile aggregates data`() = runBlocking {
-    val order = Order("order-1", "customer-1", emptyList())
-    val customer = Customer("customer-1", "Jane Doe")
-    val lineItems =
-      listOf(LineItemDetail(Product("product-1", "Coffee Mug"), Price("sku-1", 12.99), 2))
-    val expected = OrderSummary(order, customer, lineItems)
-    val testMosaic =
-      TestMosaicBuilder()
-        .withMockTile(OrderTile::class, order)
-        .withMockTile(CustomerTile::class, customer)
-        .withMockTile(LineItemsTile::class, lineItems)
-        .build()
-    testMosaic.assertEquals(OrderSummaryTile::class, expected)
-  }
-
-  @Test
-  fun `order page tile merges summary and logistics`() = runBlocking {
-    val summary =
-      OrderSummary(
-        order = Order("order-1", "customer-1", emptyList()),
-        customer = Customer("customer-1", "Jane Doe"),
-        lineItems = emptyList(),
-      )
-    val logistics = Logistics(Address("123 Main St", "Springfield"), emptyMap())
-    val expected = OrderPage(summary, logistics)
-    val testMosaic =
-      TestMosaicBuilder()
-        .withMockTile(OrderSummaryTile::class, summary)
-        .withMockTile(LogisticsTile::class, logistics)
-        .build()
-    testMosaic.assertEquals(OrderPageTile::class, expected)
-  }
+  fun `order page tile merges summary and logistics`() =
+    runBlocking {
+      val summary =
+        OrderSummary(
+          order = Order("order-1", "customer-1", emptyList()),
+          customer = Customer("customer-1", "Jane Doe"),
+          lineItems = emptyList(),
+        )
+      val logistics = Logistics(Address("123 Main St", "Springfield"), emptyMap())
+      val expected = OrderPage(summary, logistics)
+      val testMosaic =
+        TestMosaicBuilder()
+          .withMockTile(OrderSummaryTile::class, summary)
+          .withMockTile(LogisticsTile::class, logistics)
+          .build()
+      testMosaic.assertEquals(OrderPageTile::class, expected)
+    }
 }

--- a/examples/spring-example/src/test/kotlin/com/abbott/mosaic/examples/spring/orders/tile/TilesTest.kt
+++ b/examples/spring-example/src/test/kotlin/com/abbott/mosaic/examples/spring/orders/tile/TilesTest.kt
@@ -1,0 +1,166 @@
+package com.abbott.mosaic.examples.spring.orders.tile
+
+import com.abbott.mosaic.examples.spring.orders.OrderRequest
+import com.abbott.mosaic.examples.spring.orders.model.Address
+import com.abbott.mosaic.examples.spring.orders.model.Customer
+import com.abbott.mosaic.examples.spring.orders.model.LineItemDetail
+import com.abbott.mosaic.examples.spring.orders.model.Logistics
+import com.abbott.mosaic.examples.spring.orders.model.Order
+import com.abbott.mosaic.examples.spring.orders.model.OrderLineItem
+import com.abbott.mosaic.examples.spring.orders.model.OrderPage
+import com.abbott.mosaic.examples.spring.orders.model.OrderSummary
+import com.abbott.mosaic.examples.spring.orders.model.Price
+import com.abbott.mosaic.examples.spring.orders.model.Product
+import com.abbott.mosaic.examples.spring.orders.model.Quote
+import com.abbott.mosaic.test.TestMosaicBuilder
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+
+class TilesTest {
+  @Test
+  fun `order tile returns order from request`() = runBlocking {
+    val expected =
+      Order(
+        id = "order-1",
+        customerId = "customer-1",
+        items =
+          listOf(
+            OrderLineItem("product-1", "sku-1", 2),
+            OrderLineItem("product-2", "sku-2", 1),
+          ),
+      )
+    val testMosaic = TestMosaicBuilder().withRequest(OrderRequest("order-1")).build()
+    testMosaic.assertEquals(OrderTile::class, expected)
+  }
+
+  @Test
+  fun `customer tile uses order tile`() = runBlocking {
+    val order = Order("order-1", "customer-1", emptyList())
+    val expected = Customer("customer-1", "Jane Doe")
+    val testMosaic = TestMosaicBuilder().withMockTile(OrderTile::class, order).build()
+    testMosaic.assertEquals(CustomerTile::class, expected)
+  }
+
+  @Test
+  fun `products tile fetches products`() = runBlocking {
+    val keys = listOf("product-1", "product-2")
+    val expected =
+      mapOf(
+        "product-1" to Product("product-1", "Coffee Mug"),
+        "product-2" to Product("product-2", "Tea Kettle"),
+      )
+    val testMosaic = TestMosaicBuilder().build()
+    testMosaic.assertEquals(ProductsByIdTile::class, keys, expected)
+  }
+
+  @Test
+  fun `pricing tile fetches prices`() = runBlocking {
+    val keys = listOf("sku-1", "sku-2")
+    val expected =
+      mapOf(
+        "sku-1" to Price("sku-1", 12.99),
+        "sku-2" to Price("sku-2", 29.99),
+      )
+    val testMosaic = TestMosaicBuilder().build()
+    testMosaic.assertEquals(PricingBySkuTile::class, keys, expected)
+  }
+
+  @Test
+  fun `address tile uses request id`() = runBlocking {
+    val testMosaic = TestMosaicBuilder().withRequest(OrderRequest("order-1")).build()
+    val expected = Address("123 Main St", "Springfield")
+    testMosaic.assertEquals(AddressTile::class, expected)
+  }
+
+  @Test
+  fun `carrier quotes tile uses address tile`() = runBlocking {
+    val address = Address("123 Main St", "Springfield")
+    val carriers = listOf("UPS", "FEDEX")
+    val quotes =
+      mapOf(
+        "UPS" to Quote("UPS", 5.99),
+        "FEDEX" to Quote("FEDEX", 7.49),
+      )
+    val testMosaic = TestMosaicBuilder().withMockTile(AddressTile::class, address).build()
+    testMosaic.assertEquals(CarrierQuotesTile::class, carriers, quotes)
+  }
+
+  @Test
+  fun `logistics tile combines address and quotes`() = runBlocking {
+    val address = Address("123 Main St", "Springfield")
+    val quotes =
+      mapOf(
+        "UPS" to Quote("UPS", 5.99),
+        "FEDEX" to Quote("FEDEX", 7.49),
+        "DHL" to Quote("DHL", 6.49),
+      )
+    val expected = Logistics(address, quotes)
+    val testMosaic =
+      TestMosaicBuilder()
+        .withMockTile(AddressTile::class, address)
+        .withMockMultiTile(CarrierQuotesTile::class, quotes)
+        .build()
+    testMosaic.assertEquals(LogisticsTile::class, expected)
+  }
+
+  @Test
+  fun `line items tile combines other tiles`() = runBlocking {
+    val order =
+      Order(
+        id = "order-1",
+        customerId = "customer-1",
+        items = listOf(OrderLineItem("product-1", "sku-1", 2)),
+      )
+    val products = mapOf("product-1" to Product("product-1", "Coffee Mug"))
+    val prices = mapOf("sku-1" to Price("sku-1", 12.99))
+    val expected =
+      listOf(
+        LineItemDetail(
+          product = products.getValue("product-1"),
+          price = prices.getValue("sku-1"),
+          quantity = 2,
+        ),
+      )
+    val testMosaic =
+      TestMosaicBuilder()
+        .withMockTile(OrderTile::class, order)
+        .withMockMultiTile(ProductsByIdTile::class, products)
+        .withMockMultiTile(PricingBySkuTile::class, prices)
+        .build()
+    testMosaic.assertEquals(LineItemsTile::class, expected)
+  }
+
+  @Test
+  fun `order summary tile aggregates data`() = runBlocking {
+    val order = Order("order-1", "customer-1", emptyList())
+    val customer = Customer("customer-1", "Jane Doe")
+    val lineItems =
+      listOf(LineItemDetail(Product("product-1", "Coffee Mug"), Price("sku-1", 12.99), 2))
+    val expected = OrderSummary(order, customer, lineItems)
+    val testMosaic =
+      TestMosaicBuilder()
+        .withMockTile(OrderTile::class, order)
+        .withMockTile(CustomerTile::class, customer)
+        .withMockTile(LineItemsTile::class, lineItems)
+        .build()
+    testMosaic.assertEquals(OrderSummaryTile::class, expected)
+  }
+
+  @Test
+  fun `order page tile merges summary and logistics`() = runBlocking {
+    val summary =
+      OrderSummary(
+        order = Order("order-1", "customer-1", emptyList()),
+        customer = Customer("customer-1", "Jane Doe"),
+        lineItems = emptyList(),
+      )
+    val logistics = Logistics(Address("123 Main St", "Springfield"), emptyMap())
+    val expected = OrderPage(summary, logistics)
+    val testMosaic =
+      TestMosaicBuilder()
+        .withMockTile(OrderSummaryTile::class, summary)
+        .withMockTile(LogisticsTile::class, logistics)
+        .build()
+    testMosaic.assertEquals(OrderPageTile::class, expected)
+  }
+}


### PR DESCRIPTION
## Summary
- apply `testing.convention` to all example subprojects
- add mosaic-test dependency and new unit tests for spring example tiles and services
- ensure example tests meet coverage requirements

## Testing
- `./gradlew :examples:spring-example:koverVerify`


------
https://chatgpt.com/codex/tasks/task_e_68b23bd152cc8333a422e6f8a0fdae29