### PR TITLE
Add 404 handling for missing orders in Spring example

### DIFF
--- a/examples/spring-example/src/main/kotlin/com/abbott/mosaic/examples/spring/orders/tile/OrderNotFoundException.kt
+++ b/examples/spring-example/src/main/kotlin/com/abbott/mosaic/examples/spring/orders/tile/OrderNotFoundException.kt
@@ -1,0 +1,4 @@
+package com.abbott.mosaic.examples.spring.orders.tile
+
+class OrderNotFoundException(orderId: String, cause: Throwable? = null) :
+  RuntimeException("Order $orderId not found", cause)

--- a/examples/spring-example/src/main/kotlin/com/abbott/mosaic/examples/spring/orders/tile/OrderTile.kt
+++ b/examples/spring-example/src/main/kotlin/com/abbott/mosaic/examples/spring/orders/tile/OrderTile.kt
@@ -9,6 +9,10 @@ import com.abbott.mosaic.examples.spring.orders.service.OrderService
 class OrderTile(mosaic: Mosaic) : SingleTile<Order>(mosaic) {
   override suspend fun retrieve(): Order {
     val orderId = (mosaic.request as OrderRequest).orderId
-    return OrderService.getOrder(orderId)
+    return try {
+      OrderService.getOrder(orderId)
+    } catch (e: NoSuchElementException) {
+      throw OrderNotFoundException(orderId, e)
+    }
   }
 }

--- a/examples/spring-example/src/main/kotlin/com/abbott/mosaic/examples/spring/orders/web/OrderExceptionHandler.kt
+++ b/examples/spring-example/src/main/kotlin/com/abbott/mosaic/examples/spring/orders/web/OrderExceptionHandler.kt
@@ -1,0 +1,14 @@
+package com.abbott.mosaic.examples.spring.orders.web
+
+import com.abbott.mosaic.examples.spring.orders.tile.OrderNotFoundException
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ControllerAdvice
+import org.springframework.web.bind.annotation.ExceptionHandler
+
+@ControllerAdvice
+class OrderExceptionHandler {
+  @ExceptionHandler(OrderNotFoundException::class)
+  fun handle(ex: OrderNotFoundException): ResponseEntity<String> =
+    ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.message)
+}

--- a/examples/spring-example/src/test/kotlin/com/abbott/mosaic/examples/spring/orders/ApplicationTest.kt
+++ b/examples/spring-example/src/test/kotlin/com/abbott/mosaic/examples/spring/orders/ApplicationTest.kt
@@ -1,9 +1,13 @@
 package com.abbott.mosaic.examples.spring.orders
 
+import com.abbott.mosaic.examples.spring.orders.tile.OrderNotFoundException
 import com.abbott.mosaic.examples.spring.orders.web.OrderController
+import com.abbott.mosaic.examples.spring.orders.web.OrderExceptionHandler
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.http.HttpStatus
 
 class ApplicationTest {
   @Test
@@ -18,5 +22,19 @@ class ApplicationTest {
     val controller = OrderController(registry)
     val page = controller.getOrder("order-1")
     assertEquals("order-1", page.summary.order.id)
+  }
+
+  @Test
+  fun `order controller throws when missing`() {
+    val registry = MosaicConfig().mosaicRegistry()
+    val controller = OrderController(registry)
+    assertThrows<OrderNotFoundException> { controller.getOrder("missing") }
+  }
+
+  @Test
+  fun `exception handler returns 404`() {
+    val handler = OrderExceptionHandler()
+    val response = handler.handle(OrderNotFoundException("missing"))
+    assertEquals(HttpStatus.NOT_FOUND, response.statusCode)
   }
 }


### PR DESCRIPTION
## Summary
- Throw custom `OrderNotFoundException` from `OrderTile` when order ID is missing
- Map missing orders to HTTP 404 with `OrderExceptionHandler`
- Simplify controller and update tests for custom exception

## Testing
- `./gradlew clean build`


------
https://chatgpt.com/codex/tasks/task_e_68b242dbc9a8833384478dff9b37eccb