### PR TITLE
Add failure scenarios to spring example tile tests

### DIFF
--- a/examples/spring-example/src/test/kotlin/com/abbott/mosaic/examples/spring/orders/tile/AddressTileTest.kt
+++ b/examples/spring-example/src/test/kotlin/com/abbott/mosaic/examples/spring/orders/tile/AddressTileTest.kt
@@ -14,4 +14,14 @@ class AddressTileTest {
       val expected = Address("123 Main St", "Springfield")
       testMosaic.assertEquals(AddressTile::class, expected)
     }
+
+  @Test
+  fun `address tile propagates failures`() =
+    runBlocking {
+      val testMosaic =
+        TestMosaicBuilder()
+          .withFailedTile(AddressTile::class, RuntimeException("boom"))
+          .build()
+      testMosaic.assertThrows(AddressTile::class, RuntimeException::class.java)
+    }
 }

--- a/examples/spring-example/src/test/kotlin/com/abbott/mosaic/examples/spring/orders/tile/CarrierQuotesTileTest.kt
+++ b/examples/spring-example/src/test/kotlin/com/abbott/mosaic/examples/spring/orders/tile/CarrierQuotesTileTest.kt
@@ -20,4 +20,15 @@ class CarrierQuotesTileTest {
       val testMosaic = TestMosaicBuilder().withMockTile(AddressTile::class, address).build()
       testMosaic.assertEquals(CarrierQuotesTile::class, carriers, quotes)
     }
+
+  @Test
+  fun `carrier quotes tile fails when address fails`() =
+    runBlocking {
+      val carriers = listOf("UPS", "FEDEX")
+      val testMosaic =
+        TestMosaicBuilder()
+          .withFailedTile(AddressTile::class, RuntimeException("boom"))
+          .build()
+      testMosaic.assertThrows(CarrierQuotesTile::class, carriers, RuntimeException::class.java)
+    }
 }

--- a/examples/spring-example/src/test/kotlin/com/abbott/mosaic/examples/spring/orders/tile/CustomerTileTest.kt
+++ b/examples/spring-example/src/test/kotlin/com/abbott/mosaic/examples/spring/orders/tile/CustomerTileTest.kt
@@ -15,4 +15,14 @@ class CustomerTileTest {
       val testMosaic = TestMosaicBuilder().withMockTile(OrderTile::class, order).build()
       testMosaic.assertEquals(CustomerTile::class, expected)
     }
+
+  @Test
+  fun `customer tile fails when order tile fails`() =
+    runBlocking {
+      val testMosaic =
+        TestMosaicBuilder()
+          .withFailedTile(OrderTile::class, RuntimeException("boom"))
+          .build()
+      testMosaic.assertThrows(CustomerTile::class, RuntimeException::class.java)
+    }
 }

--- a/examples/spring-example/src/test/kotlin/com/abbott/mosaic/examples/spring/orders/tile/LineItemsTileTest.kt
+++ b/examples/spring-example/src/test/kotlin/com/abbott/mosaic/examples/spring/orders/tile/LineItemsTileTest.kt
@@ -37,4 +37,21 @@ class LineItemsTileTest {
           .build()
       testMosaic.assertEquals(LineItemsTile::class, expected)
     }
+
+  @Test
+  fun `line items tile fails when products tile fails`() =
+    runBlocking {
+      val order =
+        Order(
+          id = "order-1",
+          customerId = "customer-1",
+          items = listOf(OrderLineItem("product-1", "sku-1", 1)),
+        )
+      val testMosaic =
+        TestMosaicBuilder()
+          .withMockTile(OrderTile::class, order)
+          .withFailedTile(ProductsByIdTile::class, RuntimeException("boom"))
+          .build()
+      testMosaic.assertThrows(LineItemsTile::class, RuntimeException::class.java)
+    }
 }

--- a/examples/spring-example/src/test/kotlin/com/abbott/mosaic/examples/spring/orders/tile/LogisticsTileTest.kt
+++ b/examples/spring-example/src/test/kotlin/com/abbott/mosaic/examples/spring/orders/tile/LogisticsTileTest.kt
@@ -26,4 +26,16 @@ class LogisticsTileTest {
           .build()
       testMosaic.assertEquals(LogisticsTile::class, expected)
     }
+
+  @Test
+  fun `logistics tile fails when quotes tile fails`() =
+    runBlocking {
+      val address = Address("123 Main St", "Springfield")
+      val testMosaic =
+        TestMosaicBuilder()
+          .withMockTile(AddressTile::class, address)
+          .withFailedTile(CarrierQuotesTile::class, RuntimeException("boom"))
+          .build()
+      testMosaic.assertThrows(LogisticsTile::class, RuntimeException::class.java)
+    }
 }

--- a/examples/spring-example/src/test/kotlin/com/abbott/mosaic/examples/spring/orders/tile/OrderPageTileTest.kt
+++ b/examples/spring-example/src/test/kotlin/com/abbott/mosaic/examples/spring/orders/tile/OrderPageTileTest.kt
@@ -29,4 +29,21 @@ class OrderPageTileTest {
           .build()
       testMosaic.assertEquals(OrderPageTile::class, expected)
     }
+
+  @Test
+  fun `order page tile fails when logistics tile fails`() =
+    runBlocking {
+      val summary =
+        OrderSummary(
+          order = Order("order-1", "customer-1", emptyList()),
+          customer = Customer("customer-1", "Jane Doe"),
+          lineItems = emptyList(),
+        )
+      val testMosaic =
+        TestMosaicBuilder()
+          .withMockTile(OrderSummaryTile::class, summary)
+          .withFailedTile(LogisticsTile::class, RuntimeException("boom"))
+          .build()
+      testMosaic.assertThrows(OrderPageTile::class, RuntimeException::class.java)
+    }
 }

--- a/examples/spring-example/src/test/kotlin/com/abbott/mosaic/examples/spring/orders/tile/OrderSummaryTileTest.kt
+++ b/examples/spring-example/src/test/kotlin/com/abbott/mosaic/examples/spring/orders/tile/OrderSummaryTileTest.kt
@@ -27,4 +27,14 @@ class OrderSummaryTileTest {
           .build()
       testMosaic.assertEquals(OrderSummaryTile::class, expected)
     }
+
+  @Test
+  fun `order summary tile fails when order tile fails`() =
+    runBlocking {
+      val testMosaic =
+        TestMosaicBuilder()
+          .withFailedTile(OrderTile::class, RuntimeException("boom"))
+          .build()
+      testMosaic.assertThrows(OrderSummaryTile::class, RuntimeException::class.java)
+    }
 }

--- a/examples/spring-example/src/test/kotlin/com/abbott/mosaic/examples/spring/orders/tile/OrderTileTest.kt
+++ b/examples/spring-example/src/test/kotlin/com/abbott/mosaic/examples/spring/orders/tile/OrderTileTest.kt
@@ -24,4 +24,11 @@ class OrderTileTest {
       val testMosaic = TestMosaicBuilder().withRequest(OrderRequest("order-1")).build()
       testMosaic.assertEquals(OrderTile::class, expected)
     }
+
+  @Test
+  fun `order tile throws custom exception when missing`() =
+    runBlocking {
+      val testMosaic = TestMosaicBuilder().withRequest(OrderRequest("missing")).build()
+      testMosaic.assertThrows(OrderTile::class, OrderNotFoundException::class.java)
+    }
 }

--- a/examples/spring-example/src/test/kotlin/com/abbott/mosaic/examples/spring/orders/tile/OrderTotalTileTest.kt
+++ b/examples/spring-example/src/test/kotlin/com/abbott/mosaic/examples/spring/orders/tile/OrderTotalTileTest.kt
@@ -23,4 +23,14 @@ class OrderTotalTileTest {
           .build()
       testMosaic.assertEquals(OrderTotalTile::class, expected)
     }
+
+  @Test
+  fun `order total tile fails when line items fail`() =
+    runBlocking {
+      val testMosaic =
+        TestMosaicBuilder()
+          .withFailedTile(LineItemsTile::class, RuntimeException("boom"))
+          .build()
+      testMosaic.assertThrows(OrderTotalTile::class, RuntimeException::class.java)
+    }
 }

--- a/examples/spring-example/src/test/kotlin/com/abbott/mosaic/examples/spring/orders/tile/PricingBySkuTileTest.kt
+++ b/examples/spring-example/src/test/kotlin/com/abbott/mosaic/examples/spring/orders/tile/PricingBySkuTileTest.kt
@@ -18,4 +18,15 @@ class PricingBySkuTileTest {
       val testMosaic = TestMosaicBuilder().build()
       testMosaic.assertEquals(PricingBySkuTile::class, keys, expected)
     }
+
+  @Test
+  fun `pricing tile propagates failures`() =
+    runBlocking {
+      val keys = listOf("sku-1")
+      val testMosaic =
+        TestMosaicBuilder()
+          .withFailedTile(PricingBySkuTile::class, RuntimeException("boom"))
+          .build()
+      testMosaic.assertThrows(PricingBySkuTile::class, keys, RuntimeException::class.java)
+    }
 }

--- a/examples/spring-example/src/test/kotlin/com/abbott/mosaic/examples/spring/orders/tile/ProductsByIdTileTest.kt
+++ b/examples/spring-example/src/test/kotlin/com/abbott/mosaic/examples/spring/orders/tile/ProductsByIdTileTest.kt
@@ -18,4 +18,15 @@ class ProductsByIdTileTest {
       val testMosaic = TestMosaicBuilder().build()
       testMosaic.assertEquals(ProductsByIdTile::class, keys, expected)
     }
+
+  @Test
+  fun `products tile propagates failures`() =
+    runBlocking {
+      val keys = listOf("product-1")
+      val testMosaic =
+        TestMosaicBuilder()
+          .withFailedTile(ProductsByIdTile::class, RuntimeException("boom"))
+          .build()
+      testMosaic.assertThrows(ProductsByIdTile::class, keys, RuntimeException::class.java)
+    }
 }


### PR DESCRIPTION
## Summary
- add failure cases to spring example tile tests using `withFailedTile`
- verify `OrderTile` throws `OrderNotFoundException` for missing orders

## Testing
- `./gradlew clean build`


------
https://chatgpt.com/codex/tasks/task_e_68b288bf49448333844b665c42b65e01