### PR TITLE
Add KSP metadata generator module

### DIFF
--- a/mosaic-metadata/src/main/kotlin/com/abbott/mosaic/metadata/TileMetadataSymbolProcessor.kt
+++ b/mosaic-metadata/src/main/kotlin/com/abbott/mosaic/metadata/TileMetadataSymbolProcessor.kt
@@ -36,7 +36,8 @@ class TileMetadataSymbolProcessor(
     }
 
     @Suppress("SpreadOperator")
-    val dependencies = Dependencies(false, *tiles.mapNotNull { it.containingFile }.toTypedArray())
+    val dependencies =
+      Dependencies(aggregating = true, *tiles.mapNotNull { it.containingFile }.toTypedArray())
     val out =
       codeGenerator.createNewFile(
         dependencies,


### PR DESCRIPTION
## Summary
- mark generated metadata file as aggregating to ensure consistency across incremental builds

## Testing
- `./gradlew :mosaic-metadata:ktlintFormat`
- `./gradlew clean build`


------
https://chatgpt.com/codex/tasks/task_e_68b2b1641a508333a581cf8a044b7b1d