### PR TITLE
docs: refresh readme project structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,29 +40,26 @@ This project uses a **multi-module Gradle structure** to organize code into focu
 
 ```
 Mosaic/
-├── packages/
-│   ├── build.gradle.kts    # Root build configuration and publishing setup
-│   ├── settings.gradle.kts # Module definitions
-│   ├── config/             # Static analysis configs
-│   ├── mosaic-core/        # Core Mosaic framework
-│   ├── mosaic-test/        # Testing framework
-│   └── mosaic-build/       # Gradle build plugin
-├── examples/               # Standalone example projects (includes Spring Boot sample with parallel tile aggregation)
-│   ├── build.gradle.kts
-│   └── settings.gradle.kts
-└── MODULE_TEMPLATE.md      # Guide for adding new modules
+├── mosaic-core/          # Core framework
+├── mosaic-test/          # Testing framework
+├── mosaic-build-plugin/  # Gradle build plugin
+├── mosaic-build-ksp/     # KSP plugin to generate tile registration code
+├── mosaic-catalog-ksp/   # KSP plugin to generate tile catalogs for tile libraries
+├── examples/             # Example implementations
+├── buildSrc/             # Gradle convention plugins
+├── build.gradle.kts      # Root build configuration
+└── settings.gradle.kts   # Gradle settings
 ```
 
 ### **Modules**
 
-- **`mosaic-core`**: The main Mosaic framework with tile system, registry, and core functionality
-- **`mosaic-test`**: Comprehensive testing framework with utilities, assertions, and mock behaviors for testing Tile implementations
-- **`mosaic-build`**: Gradle plugin that automates Mosaic build configuration
-- **Future modules**: API, CLI, web components, utils, etc.
-
-### **Adding New Modules**
-
-See [MODULE_TEMPLATE.md](MODULE_TEMPLATE.md) for detailed instructions on adding new modules to the project.
+- **`mosaic-core`** – Core Mosaic framework with tile system, registry, and core functionality
+- **`mosaic-test`** – Comprehensive testing utilities and assertions for Tile implementations
+- **`mosaic-build-plugin`** – Gradle plugin that wires KSP processors and merges tile catalogs
+- **`mosaic-build-ksp`** – KSP plugin that generates tile registration code
+- **`mosaic-catalog-ksp`** – KSP plugin that generates tile catalogs for tile libraries
+- **`examples`** – Standalone example projects demonstrating Mosaic in real applications
+- **`buildSrc`** – Gradle convention plugins shared across modules
 
 ## 🧩 **Core Components**
 
@@ -208,10 +205,10 @@ fun `should compose complex response`() = runTest {
 
 ```bash
 # Build all modules
-./gradlew -p packages build
+./gradlew build
 
 # Build specific module
-./gradlew -p packages :mosaic-core:build
+./gradlew :mosaic-core:build
 ```
 
 ## 🧪 **Testing**
@@ -227,17 +224,17 @@ The project includes a comprehensive testing framework in the `mosaic-test` modu
 
 ```bash
 # Test all modules
-./gradlew -p packages test
+./gradlew test
 
 # Test specific module
-./gradlew -p packages :mosaic-core:test
-./gradlew -p packages :mosaic-test:test
+./gradlew :mosaic-core:test
+./gradlew :mosaic-test:test
 
 # Test with coverage verification
-./gradlew -p packages :mosaic-test:koverVerify
+./gradlew :mosaic-test:koverVerify
 
 # Generate coverage reports
-./gradlew -p packages :mosaic-test:koverHtmlReport
+./gradlew :mosaic-test:koverHtmlReport
 ```
 
 ### **Testing Examples**
@@ -277,10 +274,10 @@ Enforces Kotlin coding conventions and formatting rules.
 
 ```bash
 # Check code formatting
-./gradlew -p packages ktlintCheck
+./gradlew ktlintCheck
 
 # Auto-fix formatting issues
-./gradlew -p packages ktlintFormat
+./gradlew ktlintFormat
 ```
 
 ### **detekt** - Static Code Analysis
@@ -288,15 +285,12 @@ Performs static code analysis to detect potential bugs, code smells, and complex
 
 ```bash
 # Run static analysis
-./gradlew -p packages detekt
-
-# Run with auto-correction
-./gradlew -p packages detektMain
+./gradlew detekt
 ```
 
 ### **Configuration**
-- **ktlint**: Configured in `packages/build.gradle.kts` with version 1.0.1
-- **detekt**: Configured in `packages/config/detekt/detekt.yml` with comprehensive rule sets
+- **ktlint**: Configured via Gradle plugins with project-wide settings
+- **detekt**: Uses repository configuration to enforce best practices
 - **EditorConfig**: `.editorconfig` ensures consistent formatting across editors
 
 ### **CI/CD Integration**
@@ -305,96 +299,6 @@ The project includes GitHub Actions workflows that automatically run code qualit
 - Pushes to `main` and `develop` branches
 
 Reports are generated and stored as artifacts for review.
-
-## 🚀 **Gradle Lifecycle & Convenience Tasks**
-
-The project includes an optimized Gradle lifecycle with intelligent task dependencies and convenient shortcuts.
-
-### **Core Verification Tasks**
-
-```bash
-# Run all code style and quality checks
-./gradlew -p packages styleCheck
-
-# Run tests and verify coverage thresholds
-./gradlew -p packages coverageCheck
-
-# Run all verifications (style, quality, coverage)
-./gradlew -p packages verifyAll
-
-# Run the standard Gradle check (includes all verifications)
-./gradlew -p packages check
-```
-
-### **Convenience Tasks**
-
-```bash
-# Complete build with verification
-./gradlew -p packages fullBuild
-
-# Generate all reports (tests, coverage, style checks)
-./gradlew -p packages generateReports
-
-# Auto-fix code style issues where possible
-./gradlew -p packages fixCodeStyle
-```
-
-### **Task Dependencies**
-
-The lifecycle is organized with intelligent dependencies:
-
-- **`test`** → automatically generates HTML coverage report
-- **`styleCheck`** → runs ktlint and detekt
-- **`coverageCheck`** → runs tests and verifies coverage thresholds
-- **`verifyAll`** → runs style checks and coverage verification
-- **`check`** → includes all verifications
-- **`fullBuild`** → clean, build, test, and verify everything
-
-### **Task Groups**
-
-- **`verification`**: Code quality and testing tasks
-- **`build`**: Build and compilation tasks  
-- **`reporting`**: Report generation tasks
-
-## 📊 **Code Coverage**
-
-This project uses **Kover** for code coverage analysis, providing comprehensive insights into test coverage without affecting Kotlin compilation.
-
-### **Running Coverage Analysis**
-
-```bash
-# Generate coverage reports
-./gradlew -p packages koverHtmlReport
-
-# Generate XML report (useful for CI/CD)
-./gradlew -p packages koverXmlReport
-
-# Verify coverage meets minimum thresholds
-./gradlew -p packages koverVerify
-
-# Run all verification including coverage
-./gradlew -p packages verifyAll
-```
-
-### **Coverage Configuration**
-
-- **Minimum Thresholds**: 80% line and branch coverage
-- **Coverage Scope**: All classes in `com.abbott.mosaic.*` packages
-- **Exclusions**: Test classes and generated code are excluded
-- **Reports**: HTML and XML formats available
-
-### **Coverage Reports**
-
-After running coverage analysis, reports are available at:
-- **HTML Report**: `build/reports/kover/html/index.html`
-- **XML Report**: `build/reports/kover/xml/report.xml`
-
-### **CI/CD Integration**
-
-Coverage verification is automatically included in the build process:
-- Coverage reports are generated during CI builds
-- Coverage thresholds are enforced to maintain quality standards
-- Coverage data is available for trend analysis
 
 ## 💡 **Benefits**
 

--- a/mosaic-test/README.md
+++ b/mosaic-test/README.md
@@ -2,7 +2,7 @@
 
 [![Tests](https://github.com/Nick-Abbott/Mosaic/workflows/Test%20Badge/badge.svg)](https://github.com/Nick-Abbott/Mosaic/actions?query=workflow%3A%22Test+Badge%22)
 [![Build](https://github.com/Nick-Abbott/Mosaic/workflows/Build%20Badge/badge.svg)](https://github.com/Nick-Abbott/Mosaic/actions?query=workflow%3A%22Build+Badge%22)
-[![Kotlin](https://img.shields.io/badge/kotlin-1.9.0-blue.svg)](https://kotlinlang.org)
+[![Kotlin](https://img.shields.io/badge/kotlin-2.2.0-blue.svg)](https://kotlinlang.org)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 
 A comprehensive testing framework for the Mosaic backend orchestration system. This module provides utilities, assertions, and testing patterns specifically designed for testing Tile implementations with excellent code coverage.
@@ -19,7 +19,7 @@ The `mosaic-test` module is designed to make testing Tile implementations as eas
 ## 🏗️ Module Structure
 
 ```
-packages/mosaic-test/
+mosaic-test/
 ├── src/main/kotlin/com/abbott/mosaic/test/
 │   ├── TestMosaic.kt              # Main test wrapper with assertion methods
 │   ├── TestMosaicBuilder.kt       # Fluent builder for creating test scenarios
@@ -45,9 +45,9 @@ This module depends on:
 
 ## 🚀 Usage
 
-When the `mosaic-build` Gradle plugin is applied, the test builder automatically registers all real
-`Tile` implementations before applying mocks. If you choose to register tiles manually, you can still
-do so by calling `MosaicRegistry.register` yourself.
+When the mosaic build plugin (`com.abbott.mosaic.build`) is applied, the test builder automatically
+registers all real `Tile` implementations before applying mocks. If you choose to register tiles
+manually, you can still do so by calling `MosaicRegistry.register` yourself.
 
 ### Basic Tile Testing
 
@@ -159,7 +159,7 @@ Coverage thresholds are enforced in the build:
 - Branch coverage: 80% minimum
 - Instruction coverage: 90% minimum
 
-Run `./gradlew -p packages :mosaic-test:koverHtmlReport` to generate detailed coverage reports.
+Run `./gradlew :mosaic-test:koverHtmlReport` to generate detailed coverage reports.
 
 ## 🛠️ Development
 
@@ -174,16 +174,16 @@ Run `./gradlew -p packages :mosaic-test:koverHtmlReport` to generate detailed co
 
 ```bash
 # Run all tests
-./gradlew -p packages :mosaic-test:test
+./gradlew :mosaic-test:test
 
 # Run with coverage verification
-./gradlew -p packages :mosaic-test:koverVerify
+./gradlew :mosaic-test:koverVerify
 
 # Run specific test class
-./gradlew -p packages :mosaic-test:test --tests "com.abbott.mosaic.test.TestMosaicBuilderTest"
+./gradlew :mosaic-test:test --tests "com.abbott.mosaic.test.TestMosaicBuilderTest"
 
 # Generate coverage reports
-./gradlew -p packages :mosaic-test:koverHtmlReport
+./gradlew :mosaic-test:koverHtmlReport
 ```
 
 ### Code Quality


### PR DESCRIPTION
## Summary
- document current module layout with build and KSP plugins
- clean up README build/test commands
- update mosaic-test README with correct paths and Kotlin version

## Testing
- `./gradlew clean build`


------
https://chatgpt.com/codex/tasks/task_e_68b5d222ab0c8333ac81e937ba6fd730