### PR TITLE
Replace JUnit usage with Kotlin test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ Mosaic/
 - **Language**: Kotlin 2.2.0
 - **Build System**: Gradle with Kotlin DSL
 - **Concurrency**: Kotlin Coroutines with `Deferred` for caching
-- **Testing**: JUnit 5, Kotlin Test, Kover for coverage
+- **Testing**: Kotlin Test with Kover for coverage (Micronaut example uses JUnit 5)
 - **Code Quality**: ktlint (formatting), detekt (static analysis)
 
 ### Development Patterns

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ dependencies {
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")     // Coroutines support
   testImplementation("com.buildmosaic.test:mosaic-test:0.1.0")           // Testing utilities and mocks
   testImplementation(kotlin("test"))                                  // Kotlin test framework
-  testImplementation("org.junit.jupiter:junit-jupiter:5.10.2")       // JUnit 5
 }
 ```
 
@@ -53,7 +52,6 @@ dependencies {
   ksp("com.buildmosaic.catalog.ksp:mosaic-catalog-ksp:0.1.0")                   // Generates tile catalogs
   testImplementation("com.buildmosaic.test:mosaic-test:0.1.0")           // Testing framework
   testImplementation(kotlin("test"))                                  // Kotlin test framework
-  testImplementation("org.junit.jupiter:junit-jupiter:5.10.2")       // JUnit 5
 }
 ```
 

--- a/mosaic-core/src/test/kotlin/com/buildmosaic/core/MosaicConcurrencyTest.kt
+++ b/mosaic-core/src/test/kotlin/com/buildmosaic/core/MosaicConcurrencyTest.kt
@@ -21,8 +21,8 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.BeforeEach
 import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -34,7 +34,7 @@ class MosaicConcurrencyTest {
   private lateinit var registry: MosaicRegistry
   private lateinit var mosaic: Mosaic
 
-  @BeforeEach
+  @BeforeTest
   fun setUp() {
     registry = MosaicRegistry()
     mosaic = Mosaic(registry, TestRequest())

--- a/mosaic-core/src/test/kotlin/com/buildmosaic/core/MosaicRegistryTest.kt
+++ b/mosaic-core/src/test/kotlin/com/buildmosaic/core/MosaicRegistryTest.kt
@@ -16,7 +16,7 @@
 
 package com.buildmosaic.core
 
-import org.junit.jupiter.api.BeforeEach
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotSame
@@ -28,7 +28,7 @@ class MosaicRegistryTest {
   private lateinit var registry: MosaicRegistry
   private lateinit var mosaic: Mosaic
 
-  @BeforeEach
+  @BeforeTest
   fun setUp() {
     registry = MosaicRegistry()
     mosaic = Mosaic(registry, TestRequest())

--- a/mosaic-core/src/test/kotlin/com/buildmosaic/core/MosaicTest.kt
+++ b/mosaic-core/src/test/kotlin/com/buildmosaic/core/MosaicTest.kt
@@ -16,7 +16,7 @@
 
 package com.buildmosaic.core
 
-import org.junit.jupiter.api.BeforeEach
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -29,7 +29,7 @@ class MosaicTest {
   private lateinit var registry: MosaicRegistry
   private lateinit var mosaic: Mosaic
 
-  @BeforeEach
+  @BeforeTest
   fun setUp() {
     registry = MosaicRegistry()
     mosaic = Mosaic(registry, TestRequest())

--- a/mosaic-core/src/test/kotlin/com/buildmosaic/core/MultiTileTest.kt
+++ b/mosaic-core/src/test/kotlin/com/buildmosaic/core/MultiTileTest.kt
@@ -17,18 +17,18 @@
 package com.buildmosaic.core
 
 import kotlinx.coroutines.test.runTest
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
-import org.junit.jupiter.api.BeforeEach
-import kotlin.test.Test
-import kotlin.test.assertThrows
 import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 @Suppress("FunctionOnlyReturningConstant", "FunctionMaxLength")
 class MultiTileTest {
   private lateinit var testTile: TestMultiTile
 
-  @BeforeEach
+  @BeforeTest
   fun setUp() {
     testTile = TestMultiTile()
   }
@@ -87,7 +87,7 @@ class MultiTileTest {
       testTile.shouldThrowError = true
 
       val exception =
-        assertThrows<RuntimeException> {
+        assertFailsWith<RuntimeException> {
           testTile.getByKeys(listOf("key1", "key2"))
         }
 

--- a/mosaic-core/src/test/kotlin/com/buildmosaic/core/SingleTileTest.kt
+++ b/mosaic-core/src/test/kotlin/com/buildmosaic/core/SingleTileTest.kt
@@ -18,17 +18,17 @@ package com.buildmosaic.core
 
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
-import kotlin.test.assertEquals
-import org.junit.jupiter.api.BeforeEach
-import kotlin.test.Test
-import kotlin.test.assertThrows
 import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 @Suppress("FunctionOnlyReturningConstant", "FunctionMaxLength")
 class SingleTileTest {
   private lateinit var testTile: TestSingleTile
 
-  @BeforeEach
+  @BeforeTest
   fun setUp() {
     testTile = TestSingleTile()
   }
@@ -62,7 +62,7 @@ class SingleTileTest {
 
       // The exception should be thrown when calling get()
       val exception =
-        assertThrows<RuntimeException> {
+        assertFailsWith<RuntimeException> {
           testTile.get()
         }
 

--- a/mosaic-test/src/test/kotlin/com/buildmosaic/test/MockTileTest.kt
+++ b/mosaic-test/src/test/kotlin/com/buildmosaic/test/MockTileTest.kt
@@ -22,7 +22,7 @@ import com.buildmosaic.core.SingleTile
 import com.buildmosaic.core.Tile
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.BeforeEach
+import kotlin.test.BeforeTest
 
 /**
  * Base class for mock tile testing with common utilities.
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.BeforeEach
 abstract class MockTileTest {
   protected lateinit var mosaic: Mosaic
 
-  @BeforeEach
+  @BeforeTest
   fun setUp() {
     mosaic = mockk<Mosaic>()
   }

--- a/mosaic-test/src/test/kotlin/com/buildmosaic/test/TestMosaicTest.kt
+++ b/mosaic-test/src/test/kotlin/com/buildmosaic/test/TestMosaicTest.kt
@@ -20,7 +20,7 @@ import com.buildmosaic.core.Mosaic
 import com.buildmosaic.core.MosaicRegistry
 import com.buildmosaic.core.MosaicRequest
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.BeforeEach
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -38,7 +38,7 @@ class TestMosaicTest {
   private lateinit var request: MosaicRequest
   private lateinit var testMosaic: TestMosaic
 
-  @BeforeEach
+  @BeforeTest
   fun setUp() {
     registry = MosaicRegistry()
     request = MockMosaicRequest()


### PR DESCRIPTION
## Summary
- migrate core and test modules from JUnit imports to kotlin.test equivalents
- restore JUnit Platform runner across convention and example builds
- document Kotlin Test as the primary framework in README and AGENTS

## Testing
- `./gradlew clean build`
- `./gradlew clean build -p examples`


------
https://chatgpt.com/codex/tasks/task_e_68baa00fca188333948ac8f795158a8c