### PR TITLE
Use gradle.properties version for BOM in build plugin

### DIFF
--- a/mosaic-build-plugin/build.gradle.kts
+++ b/mosaic-build-plugin/build.gradle.kts
@@ -8,13 +8,35 @@ plugins {
   `java-gradle-plugin`
 }
 
-// Create a properties file with the version
-tasks.processResources {
-  val pluginVersion = project.property("mosaic.version") as String
-  filesMatching("mosaic-plugin.properties") {
-    expand("version" to pluginVersion)
+// Generate a Kotlin file containing the Mosaic version so the plugin can
+// reference it at compile time when applying the BOM.
+val generateVersionFile =
+  tasks.register("generateMosaicVersion") {
+    val outputDir = layout.buildDirectory.dir("generated/mosaic-version")
+    val version = project.property("mosaic.version") as String
+    outputs.dir(outputDir)
+
+    doLast {
+      val versionFile =
+        outputDir.get().file("com/buildmosaic/gradle/plugin/MosaicVersion.kt").asFile
+      versionFile.parentFile.mkdirs()
+      versionFile.writeText(
+        (
+          """
+          package com.buildmosaic.gradle.plugin
+
+          internal const val MOSAIC_VERSION: String = "$version"
+          """.trimIndent() + "\n"
+        ),
+      )
+    }
   }
+
+extensions.configure<org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension> {
+  sourceSets.getByName("main").kotlin.srcDir(generateVersionFile)
 }
+
+tasks.named("compileKotlin") { dependsOn(generateVersionFile) }
 
 dependencies {
   implementation(libs.kotlinpoet)

--- a/mosaic-build-plugin/src/main/kotlin/com/buildmosaic/gradle/plugin/MosaicConsumerPlugin.kt
+++ b/mosaic-build-plugin/src/main/kotlin/com/buildmosaic/gradle/plugin/MosaicConsumerPlugin.kt
@@ -38,7 +38,7 @@ class MosaicConsumerPlugin : Plugin<Project> {
     project.dependencies.add(
       "implementation",
       project.dependencies.platform(
-        "com.buildmosaic:mosaic-bom:0.1.0",
+        "com.buildmosaic:mosaic-bom:$MOSAIC_VERSION",
       ),
     )
 


### PR DESCRIPTION
## Summary
- Generate Mosaic version from `gradle.properties` at build time
- Use generated version constant when applying the Mosaic BOM

## Testing
- `./gradlew clean build`
- `./gradlew clean build -p examples`


------
https://chatgpt.com/codex/tasks/task_e_68bb66183fec833395518fed60530d89