### PR TITLE
feat: add functional tile core with DI

### DIFF
--- a/mosaic-core-v2/build.gradle.kts
+++ b/mosaic-core-v2/build.gradle.kts
@@ -1,0 +1,13 @@
+description = "Functional tile-based core with dependency injection"
+
+plugins {
+  id("kotlin.convention")
+  id("quality.convention")
+  id("testing.convention")
+  id("library.convention")
+}
+
+dependencies {
+  implementation(libs.kotlinx.coroutines.core)
+  testImplementation(libs.kotlinx.coroutines.test)
+}

--- a/mosaic-core-v2/src/main/kotlin/org/buildmosaic/core/vtwo/Injector.kt
+++ b/mosaic-core-v2/src/main/kotlin/org/buildmosaic/core/vtwo/Injector.kt
@@ -1,0 +1,9 @@
+package org.buildmosaic.core.vtwo
+
+import kotlin.reflect.KClass
+
+interface Injector {
+  fun <T : Any> get(type: KClass<T>): T
+}
+
+inline fun <reified T : Any> Injector.get(): T = get(T::class)

--- a/mosaic-core-v2/src/main/kotlin/org/buildmosaic/core/vtwo/Mosaic.kt
+++ b/mosaic-core-v2/src/main/kotlin/org/buildmosaic/core/vtwo/Mosaic.kt
@@ -1,0 +1,61 @@
+package org.buildmosaic.core.vtwo
+
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Per-request context used to execute tiles and access dependencies.
+ */
+class Mosaic(
+  val request: MosaicRequest,
+  @PublishedApi internal val injector: Injector,
+) {
+  private val singleCache = ConcurrentHashMap<Tile<*>, Deferred<*>>()
+  private val multiCache = ConcurrentHashMap<MultiTile<*, *>, ConcurrentHashMap<Any, Deferred<*>>>()
+  private val mutex = Mutex()
+
+  suspend fun <T> get(tile: Tile<T>): T {
+    singleCache[tile]?.let { return it.await() as T }
+    return mutex.withLock {
+      singleCache[tile]?.let { return@withLock it.await() as T }
+      val deferred = coroutineScope { async { tile.block(this@Mosaic) } }
+      singleCache[tile] = deferred
+      deferred.await() as T
+    }
+  }
+
+  suspend fun <K, V> get(
+    tile: MultiTile<K, V>,
+    keys: Collection<K>,
+  ): Map<K, V> {
+    @Suppress("UNCHECKED_CAST")
+    val cacheForTile =
+      multiCache.computeIfAbsent(tile) { ConcurrentHashMap<Any, Deferred<*>>() }
+        as ConcurrentHashMap<K, Deferred<V>>
+    val missingKeys = keys.filterNot { cacheForTile.containsKey(it) }
+    if (missingKeys.isNotEmpty()) {
+      mutex.withLock {
+        val stillMissing = missingKeys.filterNot { cacheForTile.containsKey(it) }
+        if (stillMissing.isNotEmpty()) {
+          val deferred =
+            coroutineScope { async { tile.block(this@Mosaic, stillMissing.toSet()) } }
+          stillMissing.forEach { key ->
+            cacheForTile[key] = coroutineScope { async { deferred.await()[key]!! } }
+          }
+        }
+      }
+    }
+    return keys.associateWith { cacheForTile[it]!!.await() }
+  }
+
+  suspend fun <K, V> get(
+    tile: MultiTile<K, V>,
+    vararg keys: K,
+  ): Map<K, V> = get(tile, keys.toList())
+
+  inline fun <reified T : Any> inject(): T = injector.get()
+}

--- a/mosaic-core-v2/src/main/kotlin/org/buildmosaic/core/vtwo/TileDsl.kt
+++ b/mosaic-core-v2/src/main/kotlin/org/buildmosaic/core/vtwo/TileDsl.kt
@@ -1,0 +1,65 @@
+package org.buildmosaic.core.vtwo
+
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+
+/** Representation of a single-value tile. */
+class Tile<T>(internal val block: suspend Mosaic.() -> T)
+
+fun <T> singleTile(block: suspend Mosaic.() -> T): Tile<T> = Tile(block)
+
+/** Representation of a multi-value tile. */
+class MultiTile<K, V>(internal val block: suspend Mosaic.(Set<K>) -> Map<K, V>)
+
+fun <K, V> multiTile(block: suspend Mosaic.(Set<K>) -> Map<K, V>): MultiTile<K, V> = MultiTile(block)
+
+/**
+ * Creates a [MultiTile] from a per-key fetch function.
+ *
+ * Each key is fetched independently in parallel and the results are aggregated
+ * into a map. Example:
+ *
+ * ```kotlin
+ * val userTile = perKeyTile<String, User> { id ->
+ *   service.fetchUser(id)
+ * }
+ * ```
+ */
+fun <K, V> perKeyTile(fetch: suspend Mosaic.(K) -> V): MultiTile<K, V> =
+  multiTile { keys ->
+    coroutineScope {
+      keys
+        .associateWith { key -> async { fetch(key) } }
+        .mapValues { (_, deferred) -> deferred.await() }
+    }
+  }
+
+/**
+ * Creates a [MultiTile] that splits incoming keys into batches of [batchSize]
+ * and merges the results from [fetch].
+ *
+ * ```kotlin
+ * val productTile = chunkedMultiTile<String, Product>(50) { ids ->
+ *   service.fetchProducts(ids)
+ * }
+ * ```
+ */
+fun <K, V> chunkedMultiTile(
+  batchSize: Int,
+  fetch: suspend Mosaic.(List<K>) -> Map<K, V>,
+): MultiTile<K, V> =
+  multiTile { keys ->
+    coroutineScope {
+      val result = mutableMapOf<K, V>()
+      keys
+        .chunked(batchSize)
+        .map { chunk -> async { fetch(chunk) } }
+        .awaitAll()
+        .forEach { map -> result += map }
+      result
+    }
+  }
+
+/** Simple request context that can carry arbitrary attributes. */
+data class MosaicRequest(val attributes: Map<String, Any?> = emptyMap())

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,6 +8,7 @@ pluginManagement {
 }
 
 include("mosaic-core")
+include("mosaic-core-v2")
 include("mosaic-test")
 include("mosaic-consumer-plugin")
 include("mosaic-consumer-ksp")


### PR DESCRIPTION
## Summary
- add `mosaic-core-v2` module with function-based tile DSL
- support simple dependency injection via `Injector` and `Mosaic`
- let `multiTile` blocks use the `Mosaic` receiver so context is implicit
- add per-key and chunked helpers for `MultiTile` batching
- run chunked `MultiTile` batches in parallel via coroutines
- standardize tile caching with a mutex for thread safety

## Testing
- `./gradlew ktlintFormat`
- `./gradlew clean build`


------
https://chatgpt.com/codex/tasks/task_e_68c23071f3948333bcafe41f1b9026a8